### PR TITLE
feat(portainer): add home assistant stack and static mac addresses

### DIFF
--- a/management/portainer/Pulumi.main.yaml
+++ b/management/portainer/Pulumi.main.yaml
@@ -4,6 +4,7 @@ environment:
   - homelab/plex
   - homelab/netbox
   - homelab/tailscale
+  - homelab/home-assistant
 config:
   # stack configuration
   portainer:machine-hostname: 'museum'
@@ -38,6 +39,19 @@ config:
     # cloudflare tunnel network
     - name: cfd
       type: bridge
+    # IOT internet access network
+    - name: iot-ia
+      type: macvlan
+      subnet: '192.168.100.0/24'
+      gateway: '192.168.100.1'
+      ip-range: '192.168.100.224/29'
+      parent-interface: vlan100
+    # IOT local-only network
+    - name: iot-lo
+      type: macvlan
+      subnet: '192.168.110.0/24'
+      ip-range: '192.168.110.224/29'
+      parent-interface: vlan110
 
   # traefik ingresses
   portainer:traefik-ingresses:
@@ -53,3 +67,4 @@ config:
     - media
     - netbox
     - tailscale
+    - home-assistant

--- a/management/portainer/src/TraefikStack.ts
+++ b/management/portainer/src/TraefikStack.ts
@@ -1,6 +1,6 @@
 import * as z from 'zod/v4'
 import * as pulumi from '@pulumi/pulumi'
-import { DockerCompose } from './compose'
+import { DockerCompose, generateDockerMac } from './compose'
 import {
   Network,
   NetworkDefinition,
@@ -128,6 +128,7 @@ function createComposeObject(ingressDefinition: TraefikIngressDefinition): Docke
         [ingressDefinition.bridgeNetworkName]: null,
         [ingressDefinition.macvlanNetworkName]: {
           ipv4_address: ingressDefinition.ipAddress,
+          mac_address: generateDockerMac(ingressDefinition.ipAddress),
         },
       }
     : {

--- a/management/portainer/src/networks.ts
+++ b/management/portainer/src/networks.ts
@@ -15,7 +15,7 @@ const networkSchema = z
       name: z.string(),
       type: z.literal('macvlan'),
       subnet: z.cidrv4(),
-      gateway: z.ipv4(),
+      gateway: z.ipv4().optional(),
       'ip-range': z.cidrv4(),
       'parent-interface': z.string(),
     }),
@@ -84,6 +84,7 @@ function createDockerNetwork(network: NetworkDefinition): DockerNetwork {
       }
     )
   } else {
+    const internalArg = network.gateway === undefined ? { internal: true } : {}
     return new DockerNetwork(
       `docker-network-${network.fullName}`,
       {
@@ -101,6 +102,7 @@ function createDockerNetwork(network: NetworkDefinition): DockerNetwork {
           parent: network['parent-interface'],
         },
         scope: 'local',
+        ...internalArg,
       },
       {
         provider: portainerProvider,

--- a/management/portainer/stacks/docker-compose.home-assistant.yaml
+++ b/management/portainer/stacks/docker-compose.home-assistant.yaml
@@ -1,0 +1,96 @@
+---
+version: "3.9"
+
+services:
+  hass:
+    image: ghcr.io/home-operations/home-assistant:2026.1.1@sha256:4dbdda39034b3f859ea6dc961bb12d4ccc7046a30738af8b1c2bb3188a7d6617
+    container_name: hass
+    user: 1003:3005
+    volumes:
+      - $BUILTIN__APP_DATA_HOST_PATH/hass:/config:rw
+      - $BUILTIN__APP_DATA_HOST_PATH/hass-code-server/hass-config:/config/manual:ro
+    restart: unless-stopped
+    networks:
+      home-bridge:
+      home-macvlan:
+        ipv4_address: 192.168.20.224
+      mgmt-macvlan:
+        ipv4_address: 192.168.10.224
+      iot-ia-macvlan:
+        ipv4_address: 192.168.100.224
+      iot-lo-macvlan:
+        ipv4_address: 192.168.110.224
+    environment:
+      - TZ=$BUILTIN__TIMEZONE
+      - LANG=en_US.UTF-8
+      - HASS_OIDC_CLIENT_ID=$SECRET__HASS_OIDC_CLIENT_ID
+      - HASS_OIDC_DISCOVERY_URL=https://auth.$BUILTIN__BASE_DOMAIN/.well-known/openid-configuration
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=home-bridge"
+      - "traefik.http.routers.hass.rule=Host(`hass.$BUILTIN__BASE_DOMAIN`)"
+      - "traefik.http.services.hass.loadbalancer.server.port=8123"
+
+  hass-code-auth:
+    image: ghcr.io/steveiliop56/tinyauth:v4.1.0@sha256:402ee231204757a3e01b4aaba9e4aa09a3c7c4680a82bc47135632ec8864b8c8
+    container_name: hass-code-auth
+    restart: unless-stopped
+    # Decided to not mount as this will be moved to k8s which tinyauth does not support in the same way
+    # volumes:
+    #   - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - APP_URL=https://hass-code-auth.$BUILTIN__BASE_DOMAIN
+      - PROVIDERS_POCKETID_CLIENT_ID=$SECRET__HASS_CODE_OIDC_CLIENT_ID
+      - PROVIDERS_POCKETID_CLIENT_SECRET=$SECRET__HASS_CODE_OIDC_CLIENT_SECRET
+      - PROVIDERS_POCKETID_AUTH_URL=https://auth.$BUILTIN__BASE_DOMAIN/authorize
+      - PROVIDERS_POCKETID_TOKEN_URL=https://auth.$BUILTIN__BASE_DOMAIN/api/oidc/token
+      - PROVIDERS_POCKETID_USER_INFO_URL=https://auth.$BUILTIN__BASE_DOMAIN/api/oidc/userinfo
+      - PROVIDERS_POCKETID_REDIRECT_URL=https://hass-code-auth.$BUILTIN__BASE_DOMAIN/api/oauth/callback/pocketid
+      - PROVIDERS_POCKETID_SCOPES=openid email profile groups
+      - PROVIDERS_POCKETID_NAME=Pocket ID
+      - OAUTH_AUTO_REDIRECT=pocketid
+    networks:
+      - home-bridge
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=home-bridge"
+      - "traefik.http.routers.hass-code-auth.rule=Host(`hass-code-auth.$BUILTIN__BASE_DOMAIN`)"
+      - "traefik.http.middlewares.hass-code-auth.forwardauth.address=http://hass-code-auth:3000/api/auth/traefik"
+
+  hass-code-server:
+    image: ghcr.io/linuxserver/code-server:4.108.0-ls312@sha256:982ef207e723fe04d001a9cfe58c545913c8271ae9fd4cb036fa004bfcc33631
+    container_name: hass-code-server
+    environment:
+      - PUID=1003
+      - PGID=3005
+      - TZ=$BUILTIN__TIMEZONE
+      - PROXY_DOMAIN=hass-code.$BUILTIN__BASE_DOMAIN
+      - DEFAULT_WORKSPACE=/config/projects/hass
+      - EXTENSIONS_GALLERY={"serviceUrl":"https://marketplace.visualstudio.com/_apis/public/gallery","cacheUrl":"https://vscode.blob.core.windows.net/gallery/index","itemUrl":"https://marketplace.visualstudio.com/items"}
+    volumes:
+      - $BUILTIN__APP_DATA_HOST_PATH/hass-code-server/home-dir:/config:rw
+      - $BUILTIN__APP_DATA_HOST_PATH/hass:/config/projects/hass:rw
+      - $BUILTIN__APP_DATA_HOST_PATH/hass-code-server/hass-config:/config/projects/hass/manual:rw
+    restart: unless-stopped
+    networks:
+      - home-bridge
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=home-bridge"
+      - "traefik.http.routers.hass-code.rule=Host(`hass-code.$BUILTIN__BASE_DOMAIN`)"
+      - "traefik.http.services.hass-code.loadbalancer.server.port=8443"
+      - "traefik.http.routers.hass-code.middlewares=hass-code-auth@docker"
+      # tinyauth does not support this in k8s in the same way
+      # - "tinyauth.apps.hass-code.oauth.groups=home-ops"
+
+networks:
+  home-macvlan:
+    external: true
+  home-bridge:
+    external: true
+  mgmt-macvlan:
+    external: true
+  iot-ia-macvlan:
+    external: true
+  iot-lo-macvlan:
+    external: true

--- a/renovate.json5
+++ b/renovate.json5
@@ -136,6 +136,13 @@
       versioning: "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)\\.(?<build>\\d+)-(?<hash>\\w+)-ls(?<revision>\\d+)$",
       sourceUrl: "https://github.com/linuxserver/docker-plex",
     },
+    {
+      matchDatasources: ["docker"],
+      matchPackageNames: ["ghcr.io/linuxserver/openvscode-server"],
+      description: "Get openvscode-server changelog URL from source repository",
+      versioning: "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-ls(?<revision>\\d+)$",
+      sourceUrl: "https://github.com/linuxserver/docker-openvscode-server",
+    },
   ],
   rebaseWhen: "conflicted",
   semanticCommits: "enabled",


### PR DESCRIPTION
Adds Home Assistant portainer stack including:

* Code Server for manual edits of YAML configuration
* TinyAuth to secure Code Server
* OIDC Public Client (Pocket-Id) using hass-oidc-auth

Also found an issue with MAC addresses on `macvlan` interfaces while collecting and reassigning IP addresses for devices.

Historically, Docker used a deterministic algorithm to generate MAC addresses based directly on the container's allocated IPv4 address to avoid ARP collisions. This was the default behaviour for both standard `bridge` and `macvlan` networks in Docker versions prior to 28.x. 

I wrote a function that implements the previous logic and altered the code to auto-fill the `mac_address` for `macvlan` interfaces so that they are stable in network monitoring.