### PR TITLE
feat(portainer): add seafile with notification server

### DIFF
--- a/management/portainer/AGENTS.md
+++ b/management/portainer/AGENTS.md
@@ -1,0 +1,179 @@
+# Portainer Management Agent Guide
+
+## Project Overview
+
+Infrastructure-as-code management for Docker services on Portainer running on TrueNAS Scale. Uses Pulumi to manage Docker Compose stacks, networks, Traefik proxies, and DNS records via UniFi Controller.
+
+**Goal**: Drop in docker-compose files, make minor modifications for networking/storage/env vars, and have the system validate and wire everything up automatically.
+
+## Prerequisites
+
+- TrueNAS Scale with Portainer installed
+- UniFi Controller access for DNS management
+- `mise` for managing tools and tasks
+
+## Key Commands
+
+Run these via `mise run //management/portainer:<command>`
+
+- `select`: Select the Pulumi stack
+- `preview`: Preview Pulumi changes
+- `up`: Update Pulumi stack
+- `lint`: Lint Pulumi TypeScript code
+- `shell`: Open a sub-shell in the Pulumi project
+- `exec <command>`: Execute arbitrary command in project context
+
+## Project Structure
+
+```
+stacks/
+├── docker-compose.{stack-name}.yaml    # Docker Compose files
+└── {stack-name}/                      # Optional config directory for stacks
+Pulumi.yaml                            # Main Pulumi config
+```
+
+## Configuration (Pulumi.yaml)
+
+### Networks
+
+- **Bridge**: Container-to-container communication, optional host IP binding
+- **Macvlan**: Direct network access with IPv4/IPv6 support
+
+```yaml
+config:
+  portainer:networks:
+    - name: 'home'
+      type: 'bridge'|'macvlan'
+      # Bridge: optional host-bind-ip
+      # Macvlan: ipv4/ipv6 subnets, gateways, parent-interface
+```
+
+### Traefik Ingresses
+
+One per VLAN for reverse proxy and SSL termination.
+
+```yaml
+config:
+  portainer:traefik-ingresses:
+    - network: 'home'
+      macvlan-ip: '192.168.20.225' # Optional static IP
+  portainer.traefik:hostname: 'homelab'
+  portainer.traefik:base-domain: 'gunzy.xyz'
+  portainer.traefik:app-data-host-path: '/mnt/ssdpool/appdata'
+  # Secrets: cloudflare-dns-api-token, traefik-dashboard-credentials
+```
+
+### Stacks
+
+List of active stacks to deploy:
+
+```yaml
+config:
+  portainer:stacks:
+    - 'media'
+    - 'netbox'
+```
+
+## Adding Stacks
+
+1. **Create compose file**: `stacks/docker-compose.{stack-name}.yaml`
+2. **Add to config**: Include stack name in `portainer:stacks` list
+3. **Configure networks**: Use `external: true` for pre-created networks
+4. **Set environment variables**: Use supported patterns (see below)
+5. **Add Traefik labels** (optional): For reverse proxy access
+
+### Compose File Naming
+
+- `docker-compose.media.yaml` → Stack: `media`
+- Must specify `version: '3.9'` and `container_name`
+
+### Network Connection
+
+```yaml
+networks:
+  home-bridge:
+    external: true
+  home-macvlan:
+    external: true
+```
+
+### Traefik Labels
+
+```yaml
+labels:
+  - 'traefik.enable=true'
+  - 'traefik.docker.network=home-bridge'
+  - 'traefik.http.routers.app.rule=Host(`app.gunzy.xyz`)'
+  - 'traefik.http.services.app.loadbalancer.server.port=8080'
+```
+
+## Environment Variables
+
+### Types
+
+1. **Config**: `${VAR_NAME}` - From Pulumi config `portainer.{stack}:{var}`
+2. **Secrets**: `${SECRET__VAR_NAME}` - Encrypted via `pulumi config set --secret`
+3. **Generated Passwords**: `${GEN_PASS_[LENGTH]_[CHARS]__KEY}` - Auto-generated secure passwords. LENGTH optional (default 24), CHARS optional (default SNLU where S=special chars, N=numbers, L=lowercase, U=uppercase). Use for internal service passwords.
+4. **Base64 Bytes**: `${GEN_BASE64_[LENGTH]__KEY}` - Random bytes as base64. LENGTH optional (default 32). Use for internal secrets like keys.
+5. **Built-ins**: `${BUILTIN__VAR_NAME}` - System-provided values
+
+### Secret Management
+
+- **SECRET\_\_ variables**: Must be configured in Pulumi ESC (Environment Secrets Configuration) for secure storage. Use for externally known secrets like admin passwords or OIDC credentials.
+- **After adding SECRET\_\_ variables**: Communicate to the user that they need to set these secrets in Pulumi ESC
+- **OIDC Authentication**: If configuring OIDC auth, communicate to the user that they need to set client ID and secret (or well-known endpoint for public clients) as secrets in ESC
+- **Generated passwords and base64**: Automatically generated and do not need manual setup in ESC.
+
+### Built-in Variables
+
+- `BUILTIN__TIMEZONE`: System timezone
+- `BUILTIN__BASE_DOMAIN`: Base domain for services
+- `BUILTIN__MACHINE_HOSTNAME`: Machine hostname
+- `BUILTIN__APP_DATA_HOST_PATH`: Base app data path (use to replace known host paths in volume mounts)
+- `BUILTIN__APP_CONFIG_DIR_PATH`: Host path to config directory (use to replace known host paths in volume mounts)
+- `BUILTIN__APP_CONFIG_PORTAINER_DIR_PATH`: Container path to config directory
+
+### Config Directory Upload
+
+Create `stacks/{stack-name}/` directory for config files. Automatically uploaded via SSH before deployment.
+
+## DNS Records
+
+### Automatic from Traefik Labels
+
+CNAME records created automatically from `Host(`domain`)` rules, pointing to Traefik instance.
+
+### Direct DNS Labels
+
+For bypassing Traefik: `recursive-cloud.dns.{network-name}: {domain}`
+
+Creates A/AAAA records based on network type:
+
+- **Macvlan**: A + AAAA records using static IPv4 (IPv6 auto-generated via EUI-64)
+- **Bridge**: A record using host-bind-ip
+
+## Storage Guidelines
+
+- App data: `/mnt/ssdpool/appdata/{container-name}/`
+- Bulk storage: `/mnt/pool/{dataset-name}/`
+- Communicate to the user that they must create TrueNAS datasets with appropriate permissions
+- Dedicated users/groups per stack when needed
+
+## Best Practices
+
+- Always specify `container_name`
+- Use `external: true` for networks
+- Set `restart: unless-stopped`
+- Include `TZ` environment variable
+- Use semantic versioning for image tags
+- Document service dependencies
+- Group related services in same compose file
+- Follow security practices (no-new-privileges, etc.)
+
+## Deployment Flow
+
+1. Run `mise run //management/portainer:preview` to validate changes
+2. Run `mise run //management/portainer:up` to deploy
+3. System auto-creates networks, Traefik instances, DNS records
+4. Config directories uploaded via SSH if present
+5. Environment variables processed and injected

--- a/management/portainer/Pulumi.main.yaml
+++ b/management/portainer/Pulumi.main.yaml
@@ -5,6 +5,7 @@ environment:
   - homelab/netbox
   - homelab/tailscale
   - homelab/home-assistant
+  - homelab/seafile
 config:
   # stack configuration
   portainer:machine-hostname: 'museum'
@@ -42,10 +43,14 @@ config:
         subnet: 'fd00:0:0:20::/64'
         gateway: 'fd00:0:0:20::1'
       parent-interface: vlan20
+    # netbox network
     - name: netbox
       type: bridge
     # cloudflare tunnel network
     - name: cfd
+      type: bridge
+    # seafile network
+    - name: seafile
       type: bridge
     # IOT internet access network
     - name: iot-ia
@@ -79,7 +84,8 @@ config:
     - auth
     - auth-mgmt
     - cloudflared
+    - home-assistant
     - media
     - netbox
+    - seafile
     - tailscale
-    - home-assistant

--- a/management/portainer/stacks/docker-compose.seafile.yaml
+++ b/management/portainer/stacks/docker-compose.seafile.yaml
@@ -1,0 +1,143 @@
+version: '3.9'
+
+services:
+  db:
+    image: mariadb:10.11.15@sha256:85c39719200637250bb8abe3ccd239239d6f175156fc1698141409fcf8e01a38
+    container_name: mysql-seafile
+    user: '8000:8000'
+    restart: unless-stopped
+    environment:
+      - MYSQL_ROOT_PASSWORD=$GEN_PASS__SEAFILE_MYSQL_ROOT
+      - MYSQL_LOG_CONSOLE=true
+      - MARIADB_AUTO_UPGRADE=1
+    volumes:
+      - $BUILTIN__APP_DATA_HOST_PATH/seafile-db:/var/lib/mysql
+    networks:
+      - seafile-bridge
+    healthcheck:
+      test:
+        [
+          'CMD',
+          '/usr/local/bin/healthcheck.sh',
+          '--connect',
+          '--mariadbupgrade',
+          '--innodb_initialized',
+        ]
+      interval: 20s
+      start_period: 30s
+      timeout: 5s
+      retries: 10
+
+  redis:
+    image: redis:8.4.0@sha256:73dad4271642c5966db88db7a7585fae7cf10b685d1e48006f31e0294c29fdd7
+    container_name: redis-seafile
+    restart: unless-stopped
+    command:
+      - /bin/sh
+      - -c
+      - redis-server --requirepass "$GEN_PASS__SEAFILE_REDIS"
+    environment:
+      - REDIS_PASSWORD=$GEN_PASS__SEAFILE_REDIS
+    networks:
+      - seafile-bridge
+
+  seafile:
+    image: seafileltd/seafile-mc:13.0.15@sha256:6a47d79613a2e3a31680f8ed42bea9e0ecc2df0f17e00f2e75f38489fa1d132e
+    container_name: seafile
+    restart: unless-stopped
+    volumes:
+      - /mnt/pool/seafile-data:/shared
+      - $BUILTIN__APP_CONFIG_DIR_PATH/seahub_settings.py:/shared/seafile/conf/seahub_settings.py:ro
+    environment:
+      - CACHE_PROVIDER=redis
+      - ENABLE_GO_FILESERVER=true
+      - ENABLE_NOTIFICATION_SERVER=true
+      - ENABLE_SEADOC=false
+      - ENABLE_SEAFILE_AI=false
+      - INIT_SEAFILE_ADMIN_EMAIL=$SECRET__ADMIN_EMAIL
+      - INIT_SEAFILE_ADMIN_PASSWORD=$SECRET__ADMIN_PASSWORD
+      - INIT_SEAFILE_MYSQL_ROOT_PASSWORD=$GEN_PASS__SEAFILE_MYSQL_ROOT
+      - JWT_PRIVATE_KEY=$GEN_BASE64_40__SEAFILE_JWT_PRIVATE_KEY
+      - MD_FILE_COUNT_LIMIT=100000
+      # - NON_ROOT=true
+      # - NON_ROOT_CHOWN_FILES=false
+      - OAUTH_AUTHORIZATION_URL=https://auth.$BUILTIN__BASE_DOMAIN/authorize
+      - OAUTH_CLIENT_ID=$SECRET__OAUTH_CLIENT_ID
+      - OAUTH_CLIENT_SECRET=$SECRET__OAUTH_CLIENT_SECRET
+      - OAUTH_PROVIDER_DOMAIN=https://auth.$BUILTIN__BASE_DOMAIN
+      - OAUTH_TOKEN_URL=https://auth.$BUILTIN__BASE_DOMAIN/api/oidc/token
+      - OAUTH_USER_INFO_URL=https://auth.$BUILTIN__BASE_DOMAIN/api/oidc/userinfo
+      - REDIS_HOST=redis-seafile
+      - REDIS_PASSWORD=$GEN_PASS__SEAFILE_REDIS
+      - REDIS_PORT=6379
+      - SEAFILE_DOMAIN=seafile.$BUILTIN__BASE_DOMAIN
+      - SEAFILE_LOG_TO_STDOUT=true
+      - SEAFILE_MYSQL_DB_CCNET_DB_NAME=ccnet_db
+      - SEAFILE_MYSQL_DB_HOST=mysql-seafile
+      - SEAFILE_MYSQL_DB_PASSWORD=$GEN_PASS__SEAFILE_DB_PASSWORD
+      - SEAFILE_MYSQL_DB_PORT=3306
+      - SEAFILE_MYSQL_DB_SEAFILE_DB_NAME=seafile_db
+      - SEAFILE_MYSQL_DB_SEAHUB_DB_NAME=seahub_db
+      - SEAFILE_MYSQL_DB_USER=seafile
+      - SEAFILE_SERVER_HOSTNAME=seafile.$BUILTIN__BASE_DOMAIN
+      - SEAFILE_SERVER_PROTOCOL=https
+      - SITE_ROOT=/
+      - TIME_ZONE=$BUILTIN__TIMEZONE
+    labels:
+      - traefik.enable=true
+      - traefik.docker.network=home-bridge
+      - traefik.http.routers.seafile.rule=Host(`seafile.$BUILTIN__BASE_DOMAIN`)
+      - traefik.http.services.seafile.loadbalancer.server.port=80
+    healthcheck:
+      test: ['CMD-SHELL', 'curl -f http://localhost:80 || exit 1']
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    networks:
+      - home-bridge
+      - seafile-bridge
+
+  seafile-notification:
+    image: seafileltd/notification-server:13.0.10@sha256:587b6f6fe86c5e976c08142313c05f8cba63e5eabad71006ef2ede95ed02b46d
+    container_name: seafile-notification
+    restart: always
+    volumes:
+      - /mnt/pool/seafile-data/seafile/logs:/shared/seafile/logs
+    environment:
+      - SEAFILE_MYSQL_DB_HOST=db
+      - SEAFILE_MYSQL_DB_PORT=3306
+      - SEAFILE_MYSQL_DB_USER=seafile
+      - SEAFILE_MYSQL_DB_PASSWORD=$GEN_PASS__SEAFILE_DB_PASSWORD
+      - SEAFILE_MYSQL_DB_CCNET_DB_NAME=ccnet_db
+      - SEAFILE_MYSQL_DB_SEAFILE_DB_NAME=seafile_db
+      - JWT_PRIVATE_KEY=$GEN_BASE64_40__SEAFILE_JWT_PRIVATE_KEY
+      - SEAFILE_LOG_TO_STDOUT=true
+      - NOTIFICATION_SERVER_LOG_LEVEL=info
+      # - NON_ROOT=true
+    labels:
+      - traefik.enable=true
+      - traefik.docker.network=home-bridge
+      - traefik.http.routers.notification-server.rule=Host(`seafile.$BUILTIN__BASE_DOMAIN`) && PathPrefix(`/notification`)
+      - traefik.http.services.notification-server.loadbalancer.server.port=8083
+      - traefik.http.middlewares.strip-notification.stripprefix.prefixes=/notification
+      - traefik.http.routers.my-service.middlewares=strip-notfication
+    depends_on:
+      db:
+        condition: service_healthy
+      seafile:
+        condition: service_healthy
+    networks:
+      - home-bridge
+      - seafile-bridge
+
+networks:
+  home-bridge:
+    external: true
+  seafile-bridge:
+    external: true

--- a/management/portainer/stacks/seafile/seahub_settings.py
+++ b/management/portainer/stacks/seafile/seahub_settings.py
@@ -1,0 +1,35 @@
+import os
+
+SEAFILE_DOMAIN = os.environ.get("SEAFILE_DOMAIN")
+
+CSRF_TRUSTED_ORIGINS = [f"https://{SEAFILE_DOMAIN}"]
+
+ENABLE_OAUTH = True
+OAUTH_CREATE_UNKNOWN_USER = True
+OAUTH_ACTIVATE_USER_AFTER_CREATION = True
+
+OAUTH_CLIENT_ID = os.environ.get("OAUTH_CLIENT_ID")
+OAUTH_CLIENT_SECRET = os.environ.get("OAUTH_CLIENT_SECRET")
+OAUTH_REDIRECT_URL = f"https://{SEAFILE_DOMAIN}/oauth/callback/"  # set as environment variable to pass in so it can be interpolated
+
+OAUTH_PROVIDER = "pocket-id"
+OAUTH_PROVIDER_DOMAIN = os.environ.get(
+    "OAUTH_PROVIDER_DOMAIN"
+)  # these may not be right, check pocket-id and adjust as needed
+OAUTH_AUTHORIZATION_URL = os.environ.get("OAUTH_AUTHORIZATION_URL")
+OAUTH_TOKEN_URL = os.environ.get("OAUTH_TOKEN_URL")
+OAUTH_USER_INFO_URL = os.environ.get("OAUTH_USER_INFO_URL")
+OAUTH_SCOPE = ["openid", "profile", "email"]
+OAUTH_ATTRIBUTE_MAP = {
+    "email": (True, "email"),
+    "name": (False, "name"),
+    "sub": (False, "uid"),
+}
+
+# Optionally set the following variable to automatically redirect users to the login page
+LOGIN_URL = f"https://{SEAFILE_DOMAIN}/oauth/login/"
+
+# Enable client to open an external browser for single sign on
+# When it is false, the old builtin browser is opened for single sign on
+# When it is true, the default browser of the operation system is opened
+CLIENT_SSO_VIA_LOCAL_BROWSER = True


### PR DESCRIPTION
Add [Seafile](https://github.com/haiwen/seafile) as a Dropbox replacement. Set up with OIDC authentication. Could not get it to run with NON_ROOT, will return to that later.

Also needed to add deduplication of DNS records when multiple containers are accessible from the same domain but different paths while allowing for A and AAAA records to the same endpoint.